### PR TITLE
footer primarybutton font size 수정

### DIFF
--- a/app/_components/Footer/Footer.tsx
+++ b/app/_components/Footer/Footer.tsx
@@ -3,7 +3,7 @@ import FooterItem from './FooterItem';
 const Footer = () => {
   return (
     <div
-      className="h-17 sticky bottom-0 mt-2 box-border flex w-full justify-between rounded-t-2xl bg-light-gray px-8 py-2"
+      className="sticky bottom-0 mt-2 box-border flex h-16 w-full justify-between rounded-t-2xl bg-light-gray px-8 py-2"
       style={{ boxShadow: '0px -3px 5px -2px rgb(0, 0, 0, 0.1)' }}
     >
       <FooterItem icon={'Order'} labelName={'주문내역'} to={'/'} />

--- a/app/_components/Footer/Footer.tsx
+++ b/app/_components/Footer/Footer.tsx
@@ -3,7 +3,7 @@ import FooterItem from './FooterItem';
 const Footer = () => {
   return (
     <div
-      className="h-17 fixed bottom-0 mt-2 box-border flex w-full justify-between rounded-t-2xl bg-light-gray px-8 py-2 "
+      className="h-17 sticky bottom-0 mt-2 box-border flex w-full justify-between rounded-t-2xl bg-light-gray px-8 py-2"
       style={{ boxShadow: '0px -3px 5px -2px rgb(0, 0, 0, 0.1)' }}
     >
       <FooterItem icon={'Order'} labelName={'주문내역'} to={'/'} />

--- a/app/_components/Footer/FooterItem.tsx
+++ b/app/_components/Footer/FooterItem.tsx
@@ -20,7 +20,7 @@ const FooterItem = ({ icon, labelName, to }: FooterItemPropType) => {
         ) : icon === 'MyPage' ? (
           <MyPage className="h-6 w-6" />
         ) : null}
-        <label className="cursor-pointer">{labelName}</label>
+        <label className="cursor-pointer text-xs">{labelName}</label>
       </div>
     </Link>
   );

--- a/app/_components/Footer/footer.stories.tsx
+++ b/app/_components/Footer/footer.stories.tsx
@@ -10,5 +10,9 @@ export default meta;
 type Story = StoryObj<typeof Footer>;
 
 export const Primary: Story = {
-  render: () => <Footer />,
+  render: () => (
+    <div className="fixed bottom-0 h-16 w-full">
+      <Footer />,
+    </div>
+  ),
 };

--- a/app/_components/PrimaryButton/PrimaryButton.stories.tsx
+++ b/app/_components/PrimaryButton/PrimaryButton.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof PrimaryButton> = {
 export default meta;
 type Story = StoryObj<typeof PrimaryButton>;
 
-export const Default: Story = {
+export const Primary: Story = {
   render: () => (
     <div className="fixed left-5 top-5 w-96">
       <PrimaryButton onClick={() => 'clicked'}>버튼</PrimaryButton>

--- a/app/_components/PrimaryButton/PrimaryButton.stories.tsx
+++ b/app/_components/PrimaryButton/PrimaryButton.stories.tsx
@@ -9,26 +9,10 @@ const meta: Meta<typeof PrimaryButton> = {
 export default meta;
 type Story = StoryObj<typeof PrimaryButton>;
 
-export const Large: Story = {
+export const Default: Story = {
   render: () => (
-    <div className="fixed left-5 top-5">
-      <PrimaryButton
-        size="large"
-        onClick={() => console.log('clicked')}
-        buttonText="버튼"
-      />
-    </div>
-  ),
-};
-
-export const Small: Story = {
-  render: () => (
-    <div className="fixed left-5 top-5">
-      <PrimaryButton
-        size="small"
-        buttonText="버튼"
-        onClick={() => console.log('clicked')}
-      />
+    <div className="fixed left-5 top-5 w-96">
+      <PrimaryButton onClick={() => 'clicked'}>버튼</PrimaryButton>
     </div>
   ),
 };

--- a/app/_components/PrimaryButton/PrimaryButton.tsx
+++ b/app/_components/PrimaryButton/PrimaryButton.tsx
@@ -18,7 +18,7 @@ const PrimaryButton = ({
 
   return (
     <button
-      className={`${primaryButtonSizes[size]} rounded-md bg-yellow text-black`}
+      className={`${primaryButtonSizes[size]} rounded-md bg-yellow text-base text-black`}
       onClick={onClick}
       style={{ boxShadow: '0px 0px 4px 0px rgb(0, 0, 0, 0.1)' }}
     >

--- a/app/_components/PrimaryButton/PrimaryButton.tsx
+++ b/app/_components/PrimaryButton/PrimaryButton.tsx
@@ -11,14 +11,14 @@ const PrimaryButton = ({
   buttonText,
   onClick,
 }: PrimaryButtonPropsType) => {
-  const primaryButtonSizes = {
+  const primaryButtonSizesStyles = {
     large: 'w-80 h-12',
     small: 'w-44 h-10',
   };
 
   return (
     <button
-      className={`${primaryButtonSizes[size]} rounded-md bg-yellow text-base text-black`}
+      className={`${primaryButtonSizesStyles[size]} rounded-md bg-yellow text-base text-black`}
       onClick={onClick}
       style={{ boxShadow: '0px 0px 4px 0px rgb(0, 0, 0, 0.1)' }}
     >

--- a/app/_components/PrimaryButton/PrimaryButton.tsx
+++ b/app/_components/PrimaryButton/PrimaryButton.tsx
@@ -1,28 +1,18 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 type PrimaryButtonPropsType = {
-  size: 'large' | 'small';
-  buttonText: string;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
+  children: ReactNode;
 };
 
-const PrimaryButton = ({
-  size,
-  buttonText,
-  onClick,
-}: PrimaryButtonPropsType) => {
-  const primaryButtonSizesStyles = {
-    large: 'w-80 h-12',
-    small: 'w-44 h-10',
-  };
-
+const PrimaryButton = ({ onClick, children }: PrimaryButtonPropsType) => {
   return (
     <button
-      className={`${primaryButtonSizesStyles[size]} rounded-md bg-yellow text-base text-black`}
+      className={'h-12 w-full rounded-md bg-yellow text-base text-black'}
       onClick={onClick}
       style={{ boxShadow: '0px 0px 4px 0px rgb(0, 0, 0, 0.1)' }}
     >
-      {buttonText}
+      {children}
     </button>
   );
 };


### PR DESCRIPTION
## 구현 내용
footer primarybutton font size 수정

## 스크린샷
이러한 방식으로 사용하면 될 것 같습니다!

![스크린샷 2023-11-01 시간: 04 14 00](https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-FE/assets/108605838/084fe5e3-75dd-46ee-92c2-1a804dc993bd)


![스크린샷 2023-11-01 시간: 04 11 57](https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-FE/assets/108605838/caa7f662-3712-4e1f-9db6-4026bdc8d58f)

## 참고
layout과 page를 생각해보니 Footer 컴포넌트가 쓰이는 페이지와 쓰이지 않는 페이지가 나누어져 있기 때문에 layout.tsx에 
Footer컴포넌트를 추가 하지 않았습니다.

그리고 layout.tsx의 body에 margin-left, right를 주게되면 Footer컴포넌트에도 영향이 가게 되어 layout.tsx에 Footer 컴포넌트를 
추가하지 않았으며 각 페이지에 main content를 감싸는 부분에 margin-left, right를 주는 방법이 최선일 것 같습니다.

main content의 형제 요소로 Footer컴포넌트를 사용하면 될 것 같습니다! 

## 이슈 번호

- close #54 

<!--## 테스트 계획 또는 완료 사항-->
