### PR TITLE
팝업 컴포넌트 구현

### DIFF
--- a/app/_components/infinite-scroll/LoadMoreItems.tsx
+++ b/app/_components/infinite-scroll/LoadMoreItems.tsx
@@ -41,7 +41,10 @@ const LoadMoreItems = ({
     }
   }, [inView, isEnded, loadMoreItems, isLoading]);
 
-  const scrollY = Number(sessionStorage.getItem('scrollY'));
+  const scrollY =
+    typeof window !== 'undefined'
+      ? Number(sessionStorage.getItem('scrollY'))
+      : null;
 
   if (scrollY) {
     window.scrollTo({ left: 0, top: scrollY, behavior: 'smooth' });

--- a/app/_components/pop-up/PopUp.stories.tsx
+++ b/app/_components/pop-up/PopUp.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import PopUp from './PopUp';
+
+const meta: Meta<typeof PopUp> = {
+  title: 'Components/PopUp',
+  component: PopUp,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof PopUp>;
+
+export const Primary: Story = {
+  render: () => (
+    <PopUp
+      mainText={'장바구니에는 같은 업체의 상품만 담을 수 있습니다.'}
+      subText={
+        '선택하신 상품을 장바구니에 담을 경우 이전에 담은 상품이 삭제됩니다.'
+      }
+      leftBtnText={'취소'}
+      rightBtnText={'담기'}
+      leftBtnClick={() => console.log('leftBtnClick')}
+      rightBtnClick={() => console.log('RightBtnClick')}
+    />
+  ),
+};
+
+export const MainText: Story = {
+  render: () => (
+    <PopUp
+      mainText={'재고가 부족합니다.장바구니를 초기화시키겠습니까?'}
+      leftBtnText={'취소'}
+      rightBtnText={'초기화'}
+      leftBtnClick={() => console.log('leftBtnClick')}
+      rightBtnClick={() => console.log('RightBtnClick')}
+    />
+  ),
+};

--- a/app/_components/pop-up/PopUp.tsx
+++ b/app/_components/pop-up/PopUp.tsx
@@ -1,0 +1,46 @@
+type PopUpPropsType = {
+  mainText: string;
+  subText?: string;
+  leftBtnText: string;
+  leftBtnClick: React.MouseEventHandler<HTMLButtonElement>;
+  rightBtnText: string;
+  rightBtnClick: React.MouseEventHandler<HTMLButtonElement>;
+};
+
+const PopUp = ({
+  mainText,
+  subText,
+  leftBtnText,
+  leftBtnClick,
+  rightBtnText,
+  rightBtnClick,
+}: PopUpPropsType) => {
+  return (
+    <div className="fixed left-0 top-0 flex h-full w-full items-center justify-center bg-black bg-opacity-50">
+      <div className="flex w-60 flex-col items-center rounded bg-white">
+        <div className="flex w-full flex-col items-center justify-center p-6 text-center text-sm font-semibold	">
+          <div>{mainText}</div>
+          {subText && (
+            <div className="mt-3 text-xs text-dark-gray">{subText}</div>
+          )}
+        </div>
+        <div className="flex w-full border-t-1 border-dark-gray text-sm">
+          <button
+            className="w-full rounded-bl px-4 py-3 active:bg-yellow"
+            onClick={leftBtnClick}
+          >
+            {leftBtnText}
+          </button>
+          <button
+            className="w-full rounded-br border-l-1 border-dark-gray px-4 py-3 active:bg-yellow"
+            onClick={rightBtnClick}
+          >
+            {rightBtnText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PopUp;

--- a/app/_components/pop-up/PopUp.tsx
+++ b/app/_components/pop-up/PopUp.tsx
@@ -18,8 +18,8 @@ const PopUp = ({
   return (
     <div className="fixed left-0 top-0 flex h-full w-full items-center justify-center bg-black bg-opacity-50">
       <div className="flex w-60 flex-col items-center rounded bg-white">
-        <div className="flex w-full flex-col items-center justify-center p-6 text-center text-sm font-semibold	">
-          <div>{mainText}</div>
+        <div className="flex w-full flex-col items-center justify-center p-6 text-center text-sm">
+          <div className="font-semibold">{mainText}</div>
           {subText && (
             <div className="mt-3 text-xs text-dark-gray">{subText}</div>
           )}


### PR DESCRIPTION
## 구현 내용
팝업 컴포넌트 구현하였습니다.
<!-- ## 스크린샷 -->
![스크린샷 2023-11-13 시간: 23 43 59](https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-FE/assets/108605838/26a6ab43-0be5-466a-9921-b536fc35d15f)
![스크린샷 2023-11-13 시간: 23 43 51](https://github.com/Team-PalPalHae-Dealight/Team-PalPalHae-Dealight-FE/assets/108605838/c692f39d-a451-4eee-ac7a-0fc0ad8b0d9b)

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->
구현 전, 팝업창에 필요한 내용들을 children으로 받으려고 했지만, main-text와 sub-text를 
모두 받아야 할 상황도 있기에 각각의 props로 받도록 구현하였습니다.
이 방법외에 다른 방법을 리뷰로 알려주시면 코드에 반영하도록 하겠습니다!! 

+npm run dev로 페이지를 확인해보다가 
이전에 발생하지 않았던 무한스크롤의 스크롤 이벤트 에러가 확인되어 
간단한 코드 수정 정도만 추가 커밋하였습니다. 참고 부탁드리겠습니다!
## 궁금한 점

## 이슈 번호

- close #131 

<!--## 테스트 계획 또는 완료 사항-->
