### PR TITLE
고객 주문 상세 페이지 구현하기

### DIFF
--- a/app/(main)/customer/order-detail/[id]/_components/main-contents/MainContents.tsx
+++ b/app/(main)/customer/order-detail/[id]/_components/main-contents/MainContents.tsx
@@ -17,14 +17,12 @@ type OrderResultPropsType = {
   comments: string;
 };
 
-type MainContentsPropsType = {
-  orderId: number;
-};
-
-const MainContents = ({ orderId }: MainContentsPropsType) => {
+const MainContents = () => {
   const [data, setData] = useState();
   const [order, setOrder] = useState<OrderResultPropsType>();
   console.log(data, order);
+
+  const orderId = window.location.href.split('/')[5];
 
   const sampleData = {
     storeName: '행복도너츠가게',
@@ -37,7 +35,7 @@ const MainContents = ({ orderId }: MainContentsPropsType) => {
   };
 
   const getData = useCallback(async () => {
-    const res = await getOrder(orderId);
+    const res = await getOrder(Number(orderId));
     console.log(res);
 
     /** @todo sampleData 자리에 order로 초기화, status 자리에 data.status 초기화 */
@@ -62,7 +60,7 @@ const MainContents = ({ orderId }: MainContentsPropsType) => {
       <div className="w-full p-5">
         <ProductList />
         <OrderResult data={sampleData} />
-        <ReviewButton status={sampleData.status} orderId={orderId} />
+        <ReviewButton status={sampleData.status} orderId={Number(orderId)} />
       </div>
       <CustomerFooter />
     </main>

--- a/app/(main)/customer/order-detail/[id]/_components/main-contents/MainContents.tsx
+++ b/app/(main)/customer/order-detail/[id]/_components/main-contents/MainContents.tsx
@@ -4,23 +4,65 @@ import CustomerHeader from '@/app/_components/Header/CustomerHeader';
 import ProductList from '../product-list/ProductList';
 import OrderResult from '@/app/_components/order-result/OrderResult';
 import CustomerFooter from '@/app/_components/Footer/CustomerFooter';
+import { useCallback, useEffect, useState } from 'react';
+import { getOrder } from '@/app/_services/order/getOrder';
+import ReviewButton from '../review-button/ReviewButton';
 
-const MainContents = () => {
-  /** @TODO API 연결 후 res로 받은 데이터로 초기화시키기 */
-  const data = {
+type OrderResultPropsType = {
+  storeName: string;
+  totalCount: string;
+  totalPrice: string;
+  arriveTime: string;
+  useName: string;
+  comments: string;
+};
+
+type MainContentsPropsType = {
+  orderId: number;
+};
+
+const MainContents = ({ orderId }: MainContentsPropsType) => {
+  const [data, setData] = useState();
+  const [order, setOrder] = useState<OrderResultPropsType>();
+  console.log(data, order);
+
+  const sampleData = {
     storeName: '행복도너츠가게',
     totalCount: '4',
     totalPrice: '11000',
     arriveTime: '17 : 32',
     useName: '에프와 오프',
     comments: '빨리 갈께요!',
+    status: '주문 접수',
   };
+
+  const getData = useCallback(async () => {
+    const res = await getOrder(orderId);
+    console.log(res);
+
+    /** @todo sampleData 자리에 order로 초기화, status 자리에 data.status 초기화 */
+    setData(res);
+    setOrder({
+      storeName: res.storeName,
+      totalCount: res.orderProductsRes.orderProducts.length,
+      totalPrice: res.totalPrice,
+      arriveTime: res.arrivalTime,
+      useName: res.memberNickName,
+      comments: res.demand,
+    });
+  }, [orderId]);
+
+  useEffect(() => {
+    getData();
+  }, [getData]);
+
   return (
     <main className="flex flex-col items-center">
       <CustomerHeader />
       <div className="w-full p-5">
         <ProductList />
-        <OrderResult data={data} />
+        <OrderResult data={sampleData} />
+        <ReviewButton status={sampleData.status} orderId={orderId} />
       </div>
       <CustomerFooter />
     </main>

--- a/app/(main)/customer/order-detail/[id]/_components/review-button/ReviewButton.tsx
+++ b/app/(main)/customer/order-detail/[id]/_components/review-button/ReviewButton.tsx
@@ -1,0 +1,70 @@
+import PrimaryButton from '@/app/_components/PrimaryButton/PrimaryButton';
+import pageRoute from '@/app/_constants/path';
+import { useUserInfo } from '@/app/_providers/UserInfoProvider';
+import Link from 'next/link';
+import { cancelOrder } from '../../_services/cancelOrder';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import PopUp from '@/app/_components/pop-up/PopUp';
+
+type ReviewButtonPropsType = {
+  status: string;
+  orderId: number;
+};
+
+const ReviewButton = ({ status, orderId }: ReviewButtonPropsType) => {
+  const { providerId } = useUserInfo();
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+
+  const openPopup = () => {
+    setOpen(true);
+  };
+
+  const cancel = async () => {
+    await cancelOrder(orderId);
+
+    router.push(
+      providerId
+        ? pageRoute.customer.orderList(String(providerId))
+        : pageRoute.customer.login()
+    );
+  };
+
+  return (
+    <>
+      {status === '주문 취소' ? (
+        <div className="mb-16 flex h-12 w-full items-center justify-center rounded-md bg-light-gray text-base text-red shadow">
+          주문 취소
+        </div>
+      ) : status === '주문 완료' ? (
+        <Link
+          href={
+            providerId
+              ? pageRoute.customer.reviewWrite(String(providerId))
+              : pageRoute.customer.login()
+          }
+        >
+          <PrimaryButton className="mb-16" onClick={() => {}}>
+            리뷰 작성하기
+          </PrimaryButton>
+        </Link>
+      ) : (
+        <PrimaryButton className="mb-16" onClick={openPopup}>
+          주문 취소하기
+        </PrimaryButton>
+      )}
+      {open ? (
+        <PopUp
+          mainText="주문을 취소하시겠습니까?"
+          leftBtnText="예"
+          leftBtnClick={cancel}
+          rightBtnText="아니요"
+          rightBtnClick={() => setOpen(false)}
+        ></PopUp>
+      ) : null}
+    </>
+  );
+};
+
+export default ReviewButton;

--- a/app/(main)/customer/order-detail/[id]/_services/cancelOrder.ts
+++ b/app/(main)/customer/order-detail/[id]/_services/cancelOrder.ts
@@ -1,0 +1,25 @@
+import { useRouter } from 'next/navigation';
+import { axiosInstance } from '../../../../../_services/apiClient';
+import pageRoute from '@/app/_constants/path';
+import { useUserInfo } from '@/app/_providers/UserInfoProvider';
+
+export const cancelOrder = (orderId: number) => {
+  return axiosInstance
+    .patch(`/orders/${orderId}`, {
+      status: 'CANCELED',
+    })
+    .then(function (response) {
+      console.log(response);
+    })
+    .catch(function (error) {
+      console.log(error);
+
+      const router = useRouter();
+      const { providerId } = useUserInfo();
+      router.push(
+        providerId
+          ? pageRoute.customer.orderList(String(providerId))
+          : pageRoute.customer.login()
+      );
+    });
+};

--- a/app/(main)/customer/order-detail/[id]/page.tsx
+++ b/app/(main)/customer/order-detail/[id]/page.tsx
@@ -4,7 +4,7 @@ export default function Page({ params }: { params: { slug: string } }) {
   console.log(params);
   return (
     <>
-      <MainContents orderId={1} />
+      <MainContents />
     </>
   );
 }

--- a/app/(main)/customer/order-detail/[id]/page.tsx
+++ b/app/(main)/customer/order-detail/[id]/page.tsx
@@ -4,7 +4,7 @@ export default function Page({ params }: { params: { slug: string } }) {
   console.log(params);
   return (
     <>
-      <MainContents />
+      <MainContents orderId={1} />
     </>
   );
 }

--- a/app/_components/order-result/OrderResult.tsx
+++ b/app/_components/order-result/OrderResult.tsx
@@ -12,7 +12,7 @@ const OrderResult = (props: { data: OrderResultPropsType }) => {
     props.data;
 
   return (
-    <div className="min-h-64 w-full rounded bg-white text-sm font-semibold text-black">
+    <div className="min-h-64 my-5 w-full rounded bg-white text-sm font-semibold text-black">
       <div className="p-4">
         <div className="pb-4 text-lg">주문 정보</div>
         <div className="flex justify-between pb-2.5 pr-5">

--- a/app/_services/order/getOrder.ts
+++ b/app/_services/order/getOrder.ts
@@ -1,0 +1,24 @@
+import { useRouter } from 'next/navigation';
+import { axiosInstance } from '../apiClient';
+import pageRoute from '@/app/_constants/path';
+import { useUserInfo } from '@/app/_providers/UserInfoProvider';
+
+export const getOrder = (orderId: number) => {
+  return axiosInstance
+    .get(`/orders/${orderId}`)
+    .then(function (response) {
+      console.log(response);
+      return response.data;
+    })
+    .catch(function (error) {
+      console.log(error);
+
+      const router = useRouter();
+      const { providerId } = useUserInfo();
+      router.push(
+        providerId
+          ? pageRoute.customer.orderList(String(providerId))
+          : pageRoute.customer.login()
+      );
+    });
+};


### PR DESCRIPTION
## 구현 내용
- 고객 주문 상세 페이지를 완성했습니다.
- 주문 상태에 따라 버튼을 달리 했습니다. 
- 버튼에 따른 팝업창 이벤트를 구현했습니다.
- 주문 취소 api를 연결했습니다.
- 주문 get api를 연결했습니다.

<!-- ## 스크린샷 -->

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->
- 현재 주문 더미 데이터가 없어 404 에러가 발생하는데 이는 잘못된 orderId라 발생하는 것으로 더미 데이터를 임의로 받았을 때를 가정해 ui 이벤트를 봤을 때 잘 작동되었습니다.

## 궁금한 점
- 리뷰 작성 여부를 알 수 없어 이 부분은 백엔드 분들과 상의해서 결정해야 할 듯합니다. 
- 우선 생각하고 있는 건 리뷰 post를 불렀을 때 에러가 나면 조회 페이지로 강제 이동을 구상하고 있긴 한데.. 이 부분도 아직 미흡합니다. 따라서 이 부분은 좀 더 상의가 필요합니다.


## 이슈 번호
- close #205 

<!--## 테스트 계획 또는 완료 사항-->
