### PR TITLE
이미지 patch api 연결 완료

### DIFF
--- a/app/(main)/store/my-page/[id]/_components/image-uploader/ImageUploader.tsx
+++ b/app/(main)/store/my-page/[id]/_components/image-uploader/ImageUploader.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { useRef, useState } from 'react';
+//import { patchImage } from '../../_services/patchImage';
 
 type ImageUploaderPropsType = {
   getImage: (imageUrl: string) => void;
@@ -15,6 +16,13 @@ const ImageUploader = ({ getImage }: ImageUploaderPropsType) => {
     const target = e.target as HTMLInputElement;
     const file = target.files![0];
     if (!file) return;
+
+    // await patchImage({
+    //   req: {
+    //     storeId: 1,
+    //     formData: file,
+    //   },
+    // });
 
     const reader = new FileReader();
 

--- a/app/(main)/store/my-page/[id]/_services/patchImage.ts
+++ b/app/(main)/store/my-page/[id]/_services/patchImage.ts
@@ -1,0 +1,24 @@
+import { axiosInstance } from '@/app/_services/apiClient';
+
+type ReqType = {
+  req: { storeId: number; formData: File };
+};
+
+export const patchImage = ({ req }: ReqType) => {
+  return axiosInstance
+    .patch(
+      `/stores/images/${req.storeId}`,
+      {
+        file: req.formData,
+      },
+      {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      }
+    )
+    .then(function (response) {
+      console.log(response);
+    })
+    .catch(function (error) {
+      console.log(error);
+    });
+};


### PR DESCRIPTION
## 구현 내용
- 업체 마이페이지에서 이미지를 수정하는 api를 연결했습니다.

<!-- ## 스크린샷 -->

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->
- 현재 많은 conflict가 예상되어 주석 처리했습니다.(추후 storeId와 함께 수정 예정)
- api response 값은 정상적으로 잘 나오는 것을 확인했습니다.
- 바꾼 이미지를 get으로 가져오는 것은 전 pr 에 반영되어 있으며, 전에 연결해놓은 get api의 res 중 res.image를 useState 초기값으로 설정하면 됩니다. 

## 궁금한 점
- 저는 file을 넣었더니,,, 바로 연결이 되어서... 종길님께서 진행하셨던 api와는 어떤 차이가 있었는지 모르겠지만 다음에 여유가 된다면 어떻게 해결하셨는지 듣고 싶습니다! 

## 이슈 번호
- close #207 

<!--## 테스트 계획 또는 완료 사항-->
