### PR TITLE
장바구니 담기 및 주문하기 버튼 구현 완료

### DIFF
--- a/app/(main)/customer/cart/[id]/_services/postCart.ts
+++ b/app/(main)/customer/cart/[id]/_services/postCart.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from '@/app/_services/apiClient';
+
+type ReqType = {
+  req: {
+    itemId: number;
+    cartAdditionType: 'clear' | 'check';
+  };
+};
+
+export const postCart = ({ req }: ReqType) => {
+  return axiosInstance
+    .post(`/carts/items?id=${req.itemId}&type=${req.cartAdditionType}`)
+    .then(function (response) {
+      return response;
+    })
+    .catch(function (error) {
+      return error.response;
+    });
+};

--- a/app/(main)/customer/item-detail/[id]/_components/BottomButtons.tsx
+++ b/app/(main)/customer/item-detail/[id]/_components/BottomButtons.tsx
@@ -1,12 +1,105 @@
 'use client';
 
 import PrimaryButton from '@/app/_components/PrimaryButton/PrimaryButton';
+import { postCart } from '../../../cart/[id]/_services/postCart';
+import { useState } from 'react';
+import CustomPopUp from '@/app/_components/pop-up/CustomPopUp';
+import { useRouter } from 'next/navigation';
+import pageRoute from '@/app/_constants/path';
+import PopUp from '@/app/_components/pop-up/PopUp';
+import { useUserInfo } from '@/app/_providers/UserInfoProvider';
 
-const BottomButtons = () => {
+type ItemIdType = {
+  itemId: string;
+};
+
+const BottomButtons = ({ itemId }: ItemIdType) => {
+  const [customOpen, setCustomOpen] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const router = useRouter();
+  const { providerId } = useUserInfo();
+
+  const putCart = async () => {
+    const res = await postCart({
+      req: {
+        itemId: Number(itemId),
+        cartAdditionType: 'check',
+      },
+    });
+
+    if (res.status !== 200) {
+      if (res.data.code === 'CT003' || res.data.code === 'CT005') {
+        setOpen(true);
+      } else {
+        setCustomOpen(true);
+      }
+      setMessage(res.data.message);
+    } else {
+      setMessage('해당 상품이 장바구니에 담겼습니다.');
+      setCustomOpen(true);
+    }
+  };
+
+  const clearCart = async () => {
+    const res = await postCart({
+      req: {
+        itemId: Number(itemId),
+        cartAdditionType: 'clear',
+      },
+    });
+    console.log(res);
+
+    setMessage('해당 상품이 장바구니에 담겼습니다.');
+    setCustomOpen(true);
+  };
+
+  const orderCart = async () => {
+    const res = await postCart({
+      req: {
+        itemId: Number(itemId),
+        cartAdditionType: 'check',
+      },
+    });
+
+    if (res.status !== 200) {
+      if (res.data.code === 'CT003' || res.data.code === 'CT005') {
+        setOpen(true);
+      } else {
+        setCustomOpen(true);
+      }
+      setMessage(res.data.message);
+    } else {
+      router.push(
+        providerId ? pageRoute.customer.cart(String(providerId)) : '/'
+      );
+    }
+  };
+
   return (
     <div className="flex w-full gap-5">
-      <PrimaryButton onClick={() => {}}>장바구니 담기</PrimaryButton>
-      <PrimaryButton onClick={() => {}}>주문하기</PrimaryButton>
+      <PrimaryButton onClick={putCart}>장바구니 담기</PrimaryButton>
+      <PrimaryButton onClick={orderCart}>주문하기</PrimaryButton>
+      {customOpen && (
+        <CustomPopUp
+          mainText={message}
+          btnText="다른 상품 둘러보기"
+          btnClick={() => router.push(pageRoute.customer.home())}
+        />
+      )}
+      {open && (
+        <PopUp
+          mainText={message}
+          subText="선택하신 상품을 장바구니에 담을 경우 이전에 담은 상품이 모두 삭제됩니다."
+          leftBtnText="취소"
+          leftBtnClick={() =>
+            router.push(pageRoute.customer.itemDetail(itemId))
+          }
+          rightBtnText="담기"
+          rightBtnClick={clearCart}
+        />
+      )}
     </div>
   );
 };

--- a/app/(main)/customer/item-detail/[id]/page.tsx
+++ b/app/(main)/customer/item-detail/[id]/page.tsx
@@ -9,8 +9,6 @@ const ItemDetail = dynamic(() => import('./_components/ItemDetail'), {
 });
 
 export default function Page({ params }: { params: { id: string } }) {
-  console.log(params);
-
   return (
     <>
       <CustomerHeader />
@@ -21,7 +19,7 @@ export default function Page({ params }: { params: { id: string } }) {
           상품은 해당 페이지에서 주문 수량은 1개로 제한됩니다. 추가 주문을
           원하실 경우 장바구니 페이지에서 수량을 선택할 수 있습니다.
         </Notification>
-        <BottomButtons />
+        <BottomButtons itemId={params.id} />
       </div>
       <Footer />
     </>

--- a/app/_components/pop-up/CustomPopUp.stories.tsx
+++ b/app/_components/pop-up/CustomPopUp.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CustomPopUp from './CustomPopUp';
+
+const meta: Meta<typeof CustomPopUp> = {
+  title: 'Components/CustomPopUp',
+  component: CustomPopUp,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof CustomPopUp>;
+
+export const Primary: Story = {
+  render: () => (
+    <CustomPopUp
+      mainText="본인이 등록한 업체의 상품은 장바구니에 담을 수 없습니다."
+      btnText="다른 상품 둘러보기"
+      btnClick={() => {}}
+    />
+  ),
+};

--- a/app/_components/pop-up/CustomPopUp.tsx
+++ b/app/_components/pop-up/CustomPopUp.tsx
@@ -1,0 +1,36 @@
+type PopUpPropsType = {
+  mainText: string;
+  subText?: string;
+  btnText: string;
+  btnClick: React.MouseEventHandler<HTMLButtonElement>;
+};
+
+const CustomPopUp = ({
+  mainText,
+  subText,
+  btnText,
+  btnClick,
+}: PopUpPropsType) => {
+  return (
+    <div className="fixed left-0 top-0 z-[500] flex h-full w-full items-center justify-center bg-black bg-opacity-50">
+      <div className="flex w-60 flex-col items-center rounded bg-white">
+        <div className="flex w-full flex-col items-center justify-center p-6 text-center text-sm">
+          <div className="font-semibold">{mainText}</div>
+          {subText && (
+            <div className="mt-3 text-xs text-dark-gray">{subText}</div>
+          )}
+        </div>
+        <div className="flex w-full border-t-1 border-dark-gray text-sm">
+          <button
+            className="w-full rounded-br border-l-1 border-dark-gray px-4 py-3 active:bg-yellow"
+            onClick={btnClick}
+          >
+            {btnText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CustomPopUp;


### PR DESCRIPTION
## 구현 내용
- 상품 상세 페이지에 있는 장바구니 담기 및 주문하기 기능을 구현했습니다.
- custom popup 컴포넌트를 구현했습니다. (기존의 팝업에 버튼이 하나만 존재)
- 장바구니 post 담기 api를 연결했습니다. 
- 장바구니를 초기화하는 post 분기처리했습니다.
- 그 외에 에러에 따른 분기처리를 했습니다.(에러 내용에 따라 다른 팝업 구현 및 장바구니에 정상적으로 담을 경우 팝업창 알림)

<!-- ## 스크린샷 -->

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->
- 해당 내용은 상품 상세 페이지에서의 장바구니 담기 기능입니다. 

## 궁금한 점

## 이슈 번호
- close #90 

<!--## 테스트 계획 또는 완료 사항-->
