### PR TITLE
업체 측 에러 수정

### DIFF
--- a/app/(main)/customer/item-detail/[id]/_components/BottomButtons.tsx
+++ b/app/(main)/customer/item-detail/[id]/_components/BottomButtons.tsx
@@ -15,7 +15,8 @@ type ItemIdType = {
 
 const BottomButtons = ({ itemId }: ItemIdType) => {
   const [customOpen, setCustomOpen] = useState(false);
-  const [open, setOpen] = useState(false);
+  const [clearOpen, setClearOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const [message, setMessage] = useState('');
 
   const router = useRouter();
@@ -31,7 +32,9 @@ const BottomButtons = ({ itemId }: ItemIdType) => {
 
     if (res.status !== 200) {
       if (res.data.code === 'CT003' || res.data.code === 'CT005') {
-        setOpen(true);
+        setClearOpen(true);
+      } else if (res.data.code === 'CT007' || res.data.code === 'CT008') {
+        setDeleteOpen(true);
       } else {
         setCustomOpen(true);
       }
@@ -65,7 +68,9 @@ const BottomButtons = ({ itemId }: ItemIdType) => {
 
     if (res.status !== 200) {
       if (res.data.code === 'CT003' || res.data.code === 'CT005') {
-        setOpen(true);
+        setClearOpen(true);
+      } else if (res.data.code === 'CT007' || res.data.code === 'CT008') {
+        setDeleteOpen(true);
       } else {
         setCustomOpen(true);
       }
@@ -88,16 +93,29 @@ const BottomButtons = ({ itemId }: ItemIdType) => {
           btnClick={() => setCustomOpen(false)}
         />
       )}
-      {open && (
+      {clearOpen && (
         <PopUp
           mainText={message}
           subText="선택하신 상품을 장바구니에 담을 경우 이전에 담은 상품이 모두 삭제됩니다."
           leftBtnText="취소"
-          leftBtnClick={() => setOpen(false)}
+          leftBtnClick={() => setClearOpen(false)}
           rightBtnText="담기"
           rightBtnClick={() => {
             clearCart();
-            setOpen(false);
+            setClearOpen(false);
+          }}
+        />
+      )}
+      {deleteOpen && (
+        <PopUp
+          mainText={message}
+          subText="안내한 일부 상품이 장바구니에서 삭제되며, 페이지에 있는 해당 상품은 장바구니에 담을 수 있습니다."
+          leftBtnText="취소"
+          leftBtnClick={() => setDeleteOpen(false)}
+          rightBtnText="담기"
+          rightBtnClick={() => {
+            clearCart();
+            setDeleteOpen(false);
           }}
         />
       )}

--- a/app/(main)/store/home/_components/business-status/BusinessStatus.stories.tsx
+++ b/app/(main)/store/home/_components/business-status/BusinessStatus.stories.tsx
@@ -11,5 +11,12 @@ export default meta;
 type Story = StoryObj<typeof BusinessStatus>;
 
 export const Primary: Story = {
-  render: () => <BusinessStatus setStatus={() => {}} />,
+  render: () => (
+    <BusinessStatus
+      status="영업 중"
+      setStatus={() => {
+        console.log('영업 중');
+      }}
+    />
+  ),
 };

--- a/app/(main)/store/home/_components/business-status/BusinessStatus.tsx
+++ b/app/(main)/store/home/_components/business-status/BusinessStatus.tsx
@@ -1,34 +1,25 @@
 'use client';
 
 import ToggleSwitch from '@/app/_components/toggle-switch/ToggleSwitch';
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 
 type BusinessStatusPropsType = {
+  status: string;
   setStatus: Dispatch<SetStateAction<'영업 중' | '영업 준비 중'>>;
 };
 
-const BusinessStatus = ({ setStatus }: BusinessStatusPropsType) => {
-  const [isOn, setIsOn] = useState(false);
-
-  const getBusinessStatus = (toggle: boolean) => {
-    setIsOn(toggle);
-  };
-
-  useEffect(() => {
-    getBusinessStatus(isOn);
-  }, [isOn]);
-
+const BusinessStatus = ({ status, setStatus }: BusinessStatusPropsType) => {
   return (
     <div className="flex h-11 w-full items-center justify-between rounded bg-white shadow-sm">
       <div className="flex items-center gap-x-1.5 pl-3">
         <div
-          className={`h-4 w-4 rounded-full ${isOn ? 'bg-cyan' : 'bg-red'}`}
+          className={`h-4 w-4 rounded-full ${
+            status === '영업 중' ? 'bg-cyan' : 'bg-red'
+          }`}
         />
-        <div className="text-sm font-semibold text-black">
-          {isOn ? '영업 중' : '영업 준비 중'}
-        </div>
+        <div className="text-sm font-semibold text-black">{status}</div>
       </div>
-      <ToggleSwitch getToggleValue={getBusinessStatus} setStatus={setStatus} />
+      <ToggleSwitch status={status} setStatus={setStatus} />
     </div>
   );
 };

--- a/app/(main)/store/home/_components/main-contents/MainContents.tsx
+++ b/app/(main)/store/home/_components/main-contents/MainContents.tsx
@@ -1,18 +1,31 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import BusinessStatus from '../business-status/BusinessStatus';
 import HomeButton from '../home-buttons/HomeButton';
 import ProductList from '../product-list/ProductList';
+import { getStatus } from '../../_services/getStatus';
+import { useUserInfo } from '@/app/_providers/UserInfoProvider';
 
 const MainContents = () => {
   const [status, setStatus] = useState<'영업 중' | '영업 준비 중'>(
     '영업 준비 중'
   );
+  const { storeId } = useUserInfo();
+
+  const setStoreStatus = useCallback(async () => {
+    const storeStatus = await getStatus(storeId);
+
+    setStatus(storeStatus);
+  }, [storeId]);
+
+  useEffect(() => {
+    setStoreStatus();
+  }, [setStoreStatus]);
 
   return (
     <>
-      <BusinessStatus setStatus={setStatus} />
+      <BusinessStatus status={status} setStatus={setStatus} />
       <HomeButton status={status} />
       <ProductList status={status} />
     </>

--- a/app/(main)/store/home/_services/patchStatus.ts
+++ b/app/(main)/store/home/_services/patchStatus.ts
@@ -2,14 +2,17 @@ import pageRoute from '@/app/_constants/path';
 import { axiosInstance } from '@/app/_services/apiClient';
 import { useRouter } from 'next/navigation';
 
-export const patchStatus = async (storeId: number, storeStatus: string) => {
+export const patchStatus = async (
+  storeId: number | null,
+  storeStatus: string
+) => {
   return await axiosInstance
     .patch(`/stores/status/${storeId}`, {
       storeStatus: storeStatus,
     })
 
     .then(function (response) {
-      console.log(response.data.storeStatus);
+      return response.data.storeStatus;
     })
 
     .catch(function (error) {

--- a/app/(main)/store/my-page/[id]/_components/image-uploader/ImageUploader.stories.tsx
+++ b/app/(main)/store/my-page/[id]/_components/image-uploader/ImageUploader.stories.tsx
@@ -11,5 +11,5 @@ export default meta;
 type Story = StoryObj<typeof ImageUploader>;
 
 export const Primary: Story = {
-  render: () => <ImageUploader />,
+  render: () => <ImageUploader storeImage="https://picsum.photos/200/200" />,
 };

--- a/app/(main)/store/my-page/[id]/_components/image-uploader/ImageUploader.tsx
+++ b/app/(main)/store/my-page/[id]/_components/image-uploader/ImageUploader.tsx
@@ -2,23 +2,33 @@
 
 import Image from 'next/image';
 import { useRef, useState } from 'react';
-//import { patchImage } from '../../_services/patchImage';
+import { patchImage } from '../../_services/patchImage';
+import { useUserInfo } from '@/app/_providers/UserInfoProvider';
+import { deleteImage } from '../../_services/deleteImage';
+import PopUp from '@/app/_components/pop-up/PopUp';
 
-const ImageUploader = () => {
-  const [imageUrl, setImageUrl] = useState('');
+type ImageUploaderPropsType = {
+  storeImage: string;
+};
+
+const ImageUploader = ({ storeImage }: ImageUploaderPropsType) => {
+  const [imageUrl, setImageUrl] = useState(storeImage);
+  const [openDeleteImage, setOpenDeleteImage] = useState(false);
   const fileInput = useRef(null);
+
+  const { storeId } = useUserInfo();
 
   const handleImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const target = e.target as HTMLInputElement;
     const file = target.files![0];
     if (!file) return;
 
-    // await patchImage({
-    //   req: {
-    //     storeId: 1,
-    //     formData: file,
-    //   },
-    // });
+    await patchImage({
+      req: {
+        storeId,
+        formData: file,
+      },
+    });
 
     const reader = new FileReader();
 
@@ -31,19 +41,17 @@ const ImageUploader = () => {
     };
   };
 
+  const deleteStoreImage = () => {
+    setOpenDeleteImage(true);
+  };
+
   return (
     <>
-      {imageUrl ? (
-        <div className="relative mb-2.5 h-44 w-full rounded bg-white">
-          <Image src={imageUrl} fill alt="프로필 이미지" className="rounded" />
-        </div>
-      ) : (
-        <div className="mb-2.5 flex h-44 w-full items-center justify-center rounded bg-white text-sm text-dark-gray">
-          등록된 이미지가 없습니다
-        </div>
-      )}
+      <div className="relative mb-2.5 h-44 w-full rounded bg-white">
+        <Image src={imageUrl} fill alt="프로필 이미지" className="rounded" />
+      </div>
       <label htmlFor="input-file">
-        <div className="flex h-12 w-full cursor-pointer items-center justify-center rounded-md bg-yellow text-base text-black">
+        <div className="flex h-12 w-full cursor-pointer items-center justify-center rounded-md bg-yellow text-base text-black shadow">
           업체 사진 변경하기
         </div>
       </label>
@@ -56,6 +64,26 @@ const ImageUploader = () => {
         ref={fileInput}
         onChange={handleImage}
       />
+      <button
+        className="mt-2.5 h-12 w-full rounded-md bg-light-gray text-base text-red shadow"
+        onClick={deleteStoreImage}
+      >
+        업체 사진 삭제하기
+      </button>
+      {openDeleteImage && (
+        <PopUp
+          mainText="업체 사진을 삭제하시겠습니까?"
+          subText="사진을 삭제할 경우 기본 이미지로 설정됩니다."
+          leftBtnText="아니요"
+          leftBtnClick={() => setOpenDeleteImage(false)}
+          rightBtnText="예"
+          rightBtnClick={async () => {
+            await deleteImage(storeId);
+            setOpenDeleteImage(false);
+            window.location.reload();
+          }}
+        />
+      )}
     </>
   );
 };

--- a/app/(main)/store/my-page/[id]/_components/my-page-form/MyPageForm.tsx
+++ b/app/(main)/store/my-page/[id]/_components/my-page-form/MyPageForm.tsx
@@ -2,115 +2,128 @@
 
 import { useForm, FormProvider, SubmitHandler } from 'react-hook-form';
 import ImageUploader from '../image-uploader/ImageUploader';
-//import ProfileInformation from '../profile-information/ProfileInformation';
+import ProfileInformation from '../profile-information/ProfileInformation';
 import PrimaryButton from '@/app/_components/PrimaryButton/PrimaryButton';
 import { useCallback, useEffect, useState } from 'react';
-//import StoreInformation from '../store-information/StoreInformation';
+import StoreInformation from '../store-information/StoreInformation';
 import { getProfile } from '../../_services/getProfile';
 import { useUserInfo } from '@/app/_providers/UserInfoProvider';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { object } from 'yup';
 import {
+  isValidAddress,
   isValidPhoneNumber,
-  isValidRequire,
   isValidStoreNumber,
 } from '../../_utils/validate';
 import { getMember } from '@/app/_services/member/getMember';
 import { profileType } from '../../_types/profileType';
 import ManageButton from '../manage-button/ManageButton';
 import { patchProfile } from '../../_services/patchProfile';
-import LocalStorage from '@/app/_utils/localstorage';
 import { patchMember } from '@/app/_services/member/patchMember';
 import LogoutButton from '@/app/_components/logout-button/LogoutButton';
 import Spinner from '@/app/_components/spinner/Spinner';
+import {
+  isValidStoreCloseTime,
+  isValidStoreOpenTime,
+} from '@/app/(main)/store/register-store/_utils/validate';
+import useCoordinate from '@/app/_hooks/useCoordinate';
+import { useRouter } from 'next/navigation';
+import pageRoute from '@/app/_constants/path';
+
+type MyPageInputType = {
+  userPhone: string;
+  telephone: string;
+  address: string;
+  openTime: string;
+  closeTime: string;
+  dayOff: boolean | string[];
+};
 
 const MyPageForm = () => {
-  const [profile, setProfile] = useState<profileType>();
+  const router = useRouter();
 
   const schema = object().shape({
-    addressName: isValidRequire(),
-    closeTime: isValidRequire(),
-    image: isValidRequire(),
-    name: isValidRequire(),
-    openTime: isValidRequire(),
-    storeNumber: isValidStoreNumber(),
-    storeStatus: isValidRequire(),
-    telephone: isValidStoreNumber(),
     userPhone: isValidPhoneNumber(),
-    userName: isValidRequire(),
+    telephone: isValidStoreNumber(),
+    address: isValidAddress(),
+    openTime: isValidStoreOpenTime(),
+    closeTime: isValidStoreCloseTime(),
   });
 
-  const methods = useForm<profileType>({
+  //eslint-disable-next-line
+  const methods = useForm<MyPageInputType | any>({
     resolver: yupResolver(schema),
   });
-  const { storeId } = useUserInfo();
 
-  const onSubmit: SubmitHandler<profileType> = data => {
+  const { storeAddress } = methods.watch();
+
+  const [profile, setProfile] = useState<profileType>();
+
+  const { storeId } = useUserInfo();
+  const newCoords = useCoordinate(storeAddress);
+
+  const onSubmit: SubmitHandler<MyPageInputType> = data => {
     console.log('data = ', data);
+    changeProfile();
   };
 
   const getData = useCallback(async () => {
-    const res = await getProfile(storeId);
-    const { nickName, phoneNumber, address } = await getMember();
-    const data = {
-      addressName: address.name,
-      closeTime: res.closeTime,
-      dayOff: res.dayOff,
-      image: res.image,
-      name: res.name,
-      openTime: res.openTime,
-      storeNumber: res.storeNumber,
-      storeStatus: res.storeStatus,
-      telephone: res.telephone,
-      userPhone: phoneNumber,
-      userName: nickName,
-    };
+    if (storeId) {
+      const res = await getProfile(storeId);
+      const { nickName, phoneNumber } = await getMember();
+      const data = {
+        addressName: res.addressName,
+        closeTime: res.closeTime,
+        dayOff: res.dayOff,
+        image: res.image,
+        name: res.name,
+        openTime: res.openTime,
+        storeNumber: res.storeNumber,
+        storeStatus: res.storeStatus,
+        telephone: res.telephone,
+        userPhone: phoneNumber,
+        userName: nickName,
+      };
 
-    setProfile(data);
-    LocalStorage.setItem('dealight-address', profile?.addressName);
-  }, [profile, storeId]);
+      setProfile(data);
+    }
+  }, [storeId]);
 
   const changeProfile = async () => {
-    const { userPhone, telephone, dayOff } = methods.watch();
-    const addressName = LocalStorage.getItem('dealight-address');
-    const coords = LocalStorage.getItem('dealight-coords');
-
-    const { address } = await getMember();
+    const { userPhone, telephone, storeAddress, openTime, closeTime, dayOff } =
+      methods.watch();
 
     await patchMember({
       req: {
-        nickName: profile?.userName ?? '',
+        nickName: profile?.userName ?? '딜라잇',
         phoneNumber: userPhone ?? profile?.userPhone,
-        address: address ?? {
-          name: addressName,
-          xCoordinate: coords.lat,
-          yCoordinate: coords.lng,
+        address: {
+          name: storeAddress ?? profile?.addressName,
+          xCoordinate: newCoords.lat,
+          yCoordinate: newCoords.lng,
         },
       },
     });
 
     await patchProfile({
       req: {
-        storeId: storeId ?? 1,
+        storeId,
         telephone: telephone ?? profile?.telephone,
-        addressName: addressName ?? profile?.addressName,
-        xCoordinate: coords.lat,
-        yCoordinate: coords.lng,
-        openTime: '03:00:00', //openTime === closeTime ? profile?.openTime : openTime,
-        closeTime: '06:00:00', //openTime === closeTime ? profile?.closeTime : closeTime,
+        addressName: storeAddress ?? profile?.addressName,
+        xCoordinate: newCoords.lat,
+        yCoordinate: newCoords.lng,
+        openTime: openTime ?? profile?.openTime,
+        closeTime: closeTime ?? profile?.closeTime,
         dayOff: !dayOff ? ['연중 무휴'] : dayOff,
       },
     });
+
+    router.push(pageRoute.store.home());
   };
 
   useEffect(() => {
-    if (storeId) {
-      getData();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storeId]);
-
-  console.log('profile = ', profile);
+    getData();
+  }, [getData]);
 
   return (
     <FormProvider {...methods}>
@@ -119,6 +132,8 @@ const MyPageForm = () => {
           {profile ? (
             <>
               <ImageUploader storeImage={profile.image} />
+              <ProfileInformation data={profile} />
+              <StoreInformation data={profile} />
             </>
           ) : (
             <div className="flex h-80 w-full items-center justify-center">

--- a/app/(main)/store/my-page/[id]/_components/my-page-form/MyPageForm.tsx
+++ b/app/(main)/store/my-page/[id]/_components/my-page-form/MyPageForm.tsx
@@ -2,10 +2,10 @@
 
 import { useForm, FormProvider, SubmitHandler } from 'react-hook-form';
 import ImageUploader from '../image-uploader/ImageUploader';
-import ProfileInformation from '../profile-information/ProfileInformation';
+//import ProfileInformation from '../profile-information/ProfileInformation';
 import PrimaryButton from '@/app/_components/PrimaryButton/PrimaryButton';
 import { useCallback, useEffect, useState } from 'react';
-import StoreInformation from '../store-information/StoreInformation';
+//import StoreInformation from '../store-information/StoreInformation';
 import { getProfile } from '../../_services/getProfile';
 import { useUserInfo } from '@/app/_providers/UserInfoProvider';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -22,21 +22,10 @@ import { patchProfile } from '../../_services/patchProfile';
 import LocalStorage from '@/app/_utils/localstorage';
 import { patchMember } from '@/app/_services/member/patchMember';
 import LogoutButton from '@/app/_components/logout-button/LogoutButton';
+import Spinner from '@/app/_components/spinner/Spinner';
 
 const MyPageForm = () => {
-  const [profile, setProfile] = useState<profileType>({
-    addressName: '',
-    closeTime: '',
-    dayOff: [],
-    image: '',
-    name: '',
-    openTime: '',
-    storeNumber: '',
-    storeStatus: '',
-    telephone: '',
-    userPhone: '',
-    userName: '',
-  });
+  const [profile, setProfile] = useState<profileType>();
 
   const schema = object().shape({
     addressName: isValidRequire(),
@@ -78,12 +67,11 @@ const MyPageForm = () => {
     };
 
     setProfile(data);
-    LocalStorage.setItem('dealight-address', profile.addressName);
+    LocalStorage.setItem('dealight-address', profile?.addressName);
   }, [profile, storeId]);
 
   const changeProfile = async () => {
-    const { userPhone, telephone, openTime, closeTime, dayOff } =
-      methods.watch();
+    const { userPhone, telephone, dayOff } = methods.watch();
     const addressName = LocalStorage.getItem('dealight-address');
     const coords = LocalStorage.getItem('dealight-coords');
 
@@ -91,8 +79,8 @@ const MyPageForm = () => {
 
     await patchMember({
       req: {
-        nickName: profile.userName,
-        phoneNumber: userPhone ?? profile.userPhone,
+        nickName: profile?.userName ?? '',
+        phoneNumber: userPhone ?? profile?.userPhone,
         address: address ?? {
           name: addressName,
           xCoordinate: coords.lat,
@@ -104,12 +92,12 @@ const MyPageForm = () => {
     await patchProfile({
       req: {
         storeId: storeId ?? 1,
-        telephone: telephone ?? profile.telephone,
-        addressName: addressName ?? profile.addressName,
+        telephone: telephone ?? profile?.telephone,
+        addressName: addressName ?? profile?.addressName,
         xCoordinate: coords.lat,
         yCoordinate: coords.lng,
-        openTime: openTime === closeTime ? profile.openTime : openTime,
-        closeTime: openTime === closeTime ? profile.closeTime : closeTime,
+        openTime: '03:00:00', //openTime === closeTime ? profile?.openTime : openTime,
+        closeTime: '06:00:00', //openTime === closeTime ? profile?.closeTime : closeTime,
         dayOff: !dayOff ? ['연중 무휴'] : dayOff,
       },
     });
@@ -122,13 +110,21 @@ const MyPageForm = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [storeId]);
 
+  console.log('profile = ', profile);
+
   return (
     <FormProvider {...methods}>
       <form onSubmit={methods.handleSubmit(onSubmit)}>
         <div className="flex w-full flex-col px-5 pt-5">
-          <ImageUploader />
-          <ProfileInformation data={profile} />
-          <StoreInformation data={profile} />
+          {profile ? (
+            <>
+              <ImageUploader storeImage={profile.image} />
+            </>
+          ) : (
+            <div className="flex h-80 w-full items-center justify-center">
+              <Spinner />
+            </div>
+          )}
           <PrimaryButton className="mb-5" type="submit" onClick={changeProfile}>
             정보 수정하기
           </PrimaryButton>

--- a/app/(main)/store/my-page/[id]/_components/profile-information/ProfileInformation.tsx
+++ b/app/(main)/store/my-page/[id]/_components/profile-information/ProfileInformation.tsx
@@ -25,7 +25,7 @@ const ProfileInformation = (props: { data: profileType }) => {
         <div className="flex items-center pb-2.5">
           <span>대표자 전화번호 :</span>
           <input
-            className="ml-2 flex-1 border-1 border-solid border-dark-gray p-1.5 text-sm font-normal text-dark-gray outline-none"
+            className="ml-2 flex-1 border-1 border-solid border-dark-gray p-1.5 text-sm font-normal text-black outline-none"
             type="text"
             defaultValue={props.data.userPhone}
             {...register('userPhone')}

--- a/app/(main)/store/my-page/[id]/_components/store-information/StoreInformation.tsx
+++ b/app/(main)/store/my-page/[id]/_components/store-information/StoreInformation.tsx
@@ -3,29 +3,23 @@
 import AddressButton from '@/app/_components/AddressButton/AddressButton';
 import { ErrorMessage } from '@hookform/error-message';
 import Notification from '@/app/_assets/svgs/notification.svg';
-import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { TIME_LIST } from '@/app/(main)/store/register-store/_constants/time';
 import { profileType } from '../../_types/profileType';
 import { DAY_LIST, checkboxClassName } from '../../_constants/day';
-import LocalStorage from '@/app/_utils/localstorage';
-import useCoordinate from '@/app/_hooks/useCoordinate';
 
-const StoreInformation = (props: { data: profileType }) => {
-  const [address, setAddress] = useState(
-    LocalStorage.getItem('dealight-address')
-  );
+type StoreInformationPropsType = {
+  data: profileType;
+};
 
-  const coords = useCoordinate(address);
-  LocalStorage.setItem('dealight-coords', coords);
-
+const StoreInformation = ({ data }: StoreInformationPropsType) => {
   const handleAddressButton = (address: string) => {
-    setAddress(address);
-    LocalStorage.setItem('dealight-address', address);
+    setValue('storeAddress', address);
   };
 
   const {
     register,
+    setValue,
     formState: { errors },
   } = useFormContext();
 
@@ -36,17 +30,15 @@ const StoreInformation = (props: { data: profileType }) => {
         <div className="flex justify-between pb-2.5 pr-5">
           <div>
             사업자 등록번호 :{' '}
-            <span className="font-normal text-black">
-              {props.data.storeNumber}
-            </span>
+            <span className="font-normal text-black">{data.storeNumber}</span>
           </div>
         </div>
         <div className="flex items-center pb-2.5">
           <span>업체 전화번호 :</span>
           <input
-            className="ml-2 flex-1 border-1 border-solid border-dark-gray p-1.5 text-sm font-normal text-dark-gray outline-none"
+            className="ml-2 flex-1 border-1 border-solid border-dark-gray p-1.5 text-sm font-normal text-black outline-none"
             type="text"
-            defaultValue={props.data.telephone}
+            defaultValue={data.telephone}
             {...register('telephone')}
           />
         </div>
@@ -59,31 +51,29 @@ const StoreInformation = (props: { data: profileType }) => {
             </div>
           )}
         />
-        <div className="flex items-center justify-between pb-2.5">
-          <div className="pr-0.5">업체 주소 : </div>
-          <div className="flex flex-1 items-center justify-between font-normal">
-            <div
-              className={
-                'm-1 h-8 flex-1 truncate border-1 border-solid border-dark-gray bg-white px-1 py-1.5 text-xs text-black outline-none'
-              }
-            >
-              {address === '' ? props.data.addressName : address}
-            </div>
-            <AddressButton
-              type="button"
-              getAddress={handleAddressButton}
-              className="min-w-fit rounded bg-yellow p-1.5 px-1 text-sm"
-            >
-              주소찾기
-            </AddressButton>
-          </div>
+        <div className="flex w-full items-center justify-between pb-2.5">
+          <div className="min-w-fit pr-0.5">업체 주소 : </div>
+          <input
+            className="ml-2 flex-1 overflow-auto text-ellipsis border-1 border-solid border-dark-gray p-1.5 text-sm font-normal text-black outline-none"
+            type="text"
+            disabled
+            defaultValue={data.addressName}
+            {...register('storeAddress')}
+          />
+          <AddressButton
+            type="button"
+            getAddress={handleAddressButton}
+            className="ml-2.5 min-w-fit rounded bg-yellow p-1.5 px-1 text-sm font-normal"
+          >
+            주소찾기
+          </AddressButton>
         </div>
         <div className="flex items-center justify-between pb-2.5">
           <div className="pr-2">개장 시간 :</div>
           <div className="flex flex-1 items-center justify-center border-1 border-dark-gray">
             <select
               className="h-8 w-full text-sm font-normal outline-none"
-              defaultValue={props.data.openTime}
+              defaultValue={data.openTime}
               {...register('openTime')}
             >
               {TIME_LIST.map(time => (
@@ -99,7 +89,7 @@ const StoreInformation = (props: { data: profileType }) => {
           <div className="flex flex-1 items-center justify-center border-1 border-dark-gray">
             <select
               className="h-8 w-full text-sm font-normal outline-none"
-              defaultValue={props.data.closeTime}
+              defaultValue={data.closeTime}
               {...register('closeTime')}
             >
               {TIME_LIST.map(time => (
@@ -127,7 +117,7 @@ const StoreInformation = (props: { data: profileType }) => {
             className="grid w-full grid-flow-row grid-cols-7 gap-1.5 font-normal"
           >
             {DAY_LIST.map((day: string) =>
-              props.data.dayOff && props.data.dayOff.includes(day) ? (
+              data.dayOff && data.dayOff.includes(day) ? (
                 <div className="h-12 w-full bg-white" key={day}>
                   <input
                     type="checkbox"

--- a/app/(main)/store/my-page/[id]/_services/deleteImage.ts
+++ b/app/(main)/store/my-page/[id]/_services/deleteImage.ts
@@ -1,0 +1,14 @@
+import pageRoute from '@/app/_constants/path';
+import { axiosInstance } from '@/app/_services/apiClient';
+import { useRouter } from 'next/navigation';
+
+export const deleteImage = (storeId: number | null) => {
+  return axiosInstance
+    .delete(`/stores/images/${storeId}`)
+    .catch(function (error) {
+      console.log(error);
+
+      const router = useRouter();
+      router.push(pageRoute.store.login());
+    });
+};

--- a/app/(main)/store/my-page/[id]/_services/patchImage.ts
+++ b/app/(main)/store/my-page/[id]/_services/patchImage.ts
@@ -1,7 +1,7 @@
 import { axiosInstance } from '@/app/_services/apiClient';
 
 type ReqType = {
-  req: { storeId: number; formData: File };
+  req: { storeId: number | null; formData: File };
 };
 
 export const patchImage = ({ req }: ReqType) => {

--- a/app/(main)/store/my-page/[id]/_types/profileType.ts
+++ b/app/(main)/store/my-page/[id]/_types/profileType.ts
@@ -13,9 +13,9 @@ export type profileType = {
 };
 
 export type PatchProfileType = {
-  storeId: number;
+  storeId: number | null;
   telephone: string;
-  addressName: string;
+  addressName: string | undefined;
   xCoordinate: number;
   yCoordinate: number;
   openTime: string;

--- a/app/(main)/store/my-page/[id]/_utils/validate.ts
+++ b/app/(main)/store/my-page/[id]/_utils/validate.ts
@@ -25,3 +25,9 @@ export const isValidPhoneNumber = () => {
     .matches(/^[0-9]+$/, ERROR_MESSAGE.STORE_NUMBER)
     .length(11, ERROR_MESSAGE.STORE_LENGTH);
 };
+
+export const isValidAddress = () => {
+  return string()
+    .required(ERROR_MESSAGE.STORE_REQUIRED)
+    .min(2, ERROR_MESSAGE.STORE_MIN);
+};

--- a/app/_components/toggle-switch/ToggleSwitch.stories.tsx
+++ b/app/_components/toggle-switch/ToggleSwitch.stories.tsx
@@ -12,9 +12,6 @@ type Story = StoryObj<typeof ToggleSwitch>;
 
 export const Primary: Story = {
   render: () => (
-    <ToggleSwitch
-      getToggleValue={toggle => console.log(toggle)}
-      setStatus={() => {}}
-    />
+    <ToggleSwitch status="영업 중" setStatus={() => console.log('영업 중')} />
   ),
 };

--- a/app/_types/member/profileType.ts
+++ b/app/_types/member/profileType.ts
@@ -1,6 +1,6 @@
 export type profileType = {
   address: {
-    name: string;
+    name: string | undefined;
     xCoordinate: number;
     yCoordinate: number;
   };


### PR DESCRIPTION
## 구현 내용
업체 홈 페이지의 에러 사항과 업체 마이페이지의 에러 사항 수정했습니다.

- 영업 상태 토글 초기값 수정했습니다. 그러면서 status로 값을 통일했으며 리팩토링을 진행했습니다.(새로고침 또는 페이지 전환시 서버 데이터 적용)
- 업체 마이페이지 get 반영(select, checkbox) 전에는 서버 데이터가 불러져 왔지만 폼에 적용이 되지 않았다면 서버 휴무일이 checkbox에 적용되고, 서버 영업 시간이 폼 select에 적용되어 바로 띄도록 설정했습니다. 따라서 기본적으로 입력값을 입력하지 않고 정보 수정하기 버튼을 클릭해도 기존의 서버 데이터로 보내져 에러가 발생하지 않습니다.(이럴 경우 기존 정보를 그대로 req로 보냄)
- 업체 마이페이지 이미지 적용 에러 사항 수정했습니다. 서버에 디포르 이미지를 설정해주셨기 때문에 이 부분을 이용해 이미지가 없을 경우 디폴트 이미지를, 이미지가 있을 경우 그 이미지를 띄우도록 설정했습니다.
- 업체 마이페이지 이미지 변경 에러 사항 수정했습니다.
- 업체 마이페이지에 업체 사진 삭제하기 기능을 추가했습니다. api에 삭제하기 기능이 있었고, 사용자가 이미지를 선택한 뒤 다시 디폴트 이미지로 돌아가고 싶을 수도 있을 듯하여, 이미지 삭제하기를 넣었으며, 삭제할 경우 디폴트 이미지로 설정됩니다.
- 이미지 삭제하기 팝업 창을 추가했습니다.
- 장바구니 예외 상황이 추가되어 예외 로직 추가했습니다.

<!-- ## 스크린샷 -->

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->
- 이제 맡은 바 담당 구역이 모두 끝났습니다.(예외처리, 에러 해결, ui, ux)
- 남은 시간 동안은 다른 해야할 일을 하거나 디자인만 전체적으로 손볼 것 같습니다.
- 혹시 해결해야 하는 작업이 있고, 도움이 필요하다면 슬랙으로 멘션 부탁드립니다!
 
## 궁금한 점

## 이슈 번호
- close #238 

<!--## 테스트 계획 또는 완료 사항-->
